### PR TITLE
Use existing role model for ts/destroy (#113)

### DIFF
--- a/app/domain/ts/interface.rb
+++ b/app/domain/ts/interface.rb
@@ -34,6 +34,10 @@ class Ts::Interface
     request(:put, code, ts_model.to_xml)
   end
 
+  def client
+    @client ||= Ts::Client.new(ts_model.class, nesting: nesting)
+  end
+
   private
 
   def ts_code? = model.ts_code.present?
@@ -62,9 +66,5 @@ class Ts::Interface
       METHOD: #{method}
       #{args.join(", ")}
     TEXT
-  end
-
-  def client
-    @client ||= Ts::Client.new(ts_model.class, nesting: nesting)
   end
 end

--- a/app/jobs/ts/role_destroy_job.rb
+++ b/app/jobs/ts/role_destroy_job.rb
@@ -8,15 +8,13 @@
 class Ts::RoleDestroyJob < BaseJob
   self.parameters = [:attrs]
 
-  attr_reader :attrs
+  attr_reader :attrs, :role
 
   def initialize(attrs)
     @attrs = attrs
+    @role = Role.with_inactive.find_by(id: attrs[:id]) || attrs[:type].constantize.new(attrs)
+    @role.attributes = attrs.except(:id)
   end
 
   def perform = (role.ts_interface_put if role.ts_code)
-
-  private
-
-  def role = @role ||= attrs[:type].constantize.new(attrs)
 end

--- a/spec/jobs/ts/role_destroy_job_spec.rb
+++ b/spec/jobs/ts/role_destroy_job_spec.rb
@@ -13,7 +13,7 @@ describe Ts::RoleDestroyJob do
   let(:interface) { instance_double(Ts::Interface) }
   let(:attrs) { %w[id code group_id person_id start_on] }
 
-  it "uses interface to post" do
+  it "uses interface to post with persisted" do
     expect(Ts::Interface).to receive(:new) do |role_proxy, args|
       expect(args[:nesting]).to eq person.ts_model
       expect(role_proxy).to be_persisted
@@ -23,7 +23,7 @@ describe Ts::RoleDestroyJob do
     described_class.new(role.ts_destroy_values).perform
   end
 
-  it "uses interface to post with non persisted model" do
+  it "uses interface to post with non persisted model if model no longer exists" do
     expect(Ts::Interface).to receive(:new) do |role_proxy, args|
       expect(args[:nesting]).to eq person.ts_model
       expect(role_proxy).not_to be_persisted

--- a/spec/jobs/ts/role_destroy_job_spec.rb
+++ b/spec/jobs/ts/role_destroy_job_spec.rb
@@ -16,10 +16,23 @@ describe Ts::RoleDestroyJob do
   it "uses interface to post" do
     expect(Ts::Interface).to receive(:new) do |role_proxy, args|
       expect(args[:nesting]).to eq person.ts_model
-      expect(role_proxy.attributes.compact_blank.symbolize_keys).to eq role.ts_destroy_values
+      expect(role_proxy).to be_persisted
+      expect(role_proxy.attributes.compact_blank.symbolize_keys).to include(role.ts_destroy_values)
     end.and_return(interface)
     expect(interface).to receive(:put)
     described_class.new(role.ts_destroy_values).perform
+  end
+
+  it "uses interface to post with non persisted model" do
+    expect(Ts::Interface).to receive(:new) do |role_proxy, args|
+      expect(args[:nesting]).to eq person.ts_model
+      expect(role_proxy).not_to be_persisted
+      expect(role_proxy.attributes.compact_blank.symbolize_keys).to include(role.ts_destroy_values)
+    end.and_return(interface)
+    expect(interface).to receive(:put)
+    destroy_values = role.ts_destroy_values
+    Role.where(id: role.id).delete_all
+    described_class.new(destroy_values).perform
   end
 
   it "noops when role has no ts_code set" do


### PR DESCRIPTION
This prevents the Problem, where in case of an error, the LogEntry
cannot be written, because the subject (=role) already exists.
