### PR TITLE
Configure member_id as public table column (hitobito/hitobito#139)

### DIFF
--- a/lib/hitobito_swb/wagon.rb
+++ b/lib/hitobito_swb/wagon.rb
@@ -46,6 +46,8 @@ module HitobitoSwb
 
       Export::Tabular::People::PeopleAddress.prepend Swb::Export::Tabular::People::PeopleAddress
 
+      TableDisplay.register_column(Person, TableDisplays::PublicColumn, [:member_id])
+
       # Tournaments with questions
       EventAbility.prepend Swb::EventAbility
       GroupAbility.prepend Swb::GroupAbility


### PR DESCRIPTION
Damit kann die MemberID als Spalte ausgewählt und exportiert werden:
<img width="377" height="494" alt="image" src="https://github.com/user-attachments/assets/f38d6a5d-72d4-4b99-9138-5ac787805ee2" />

Fixes https://github.com/hitobito/hitobito_swb/issues/139