### PR TITLE
Add language to new person form (hitobito/hitobito_swb#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 * Tournamentsoftware API integration wurde umgesetzt (#16)
 * Gründungsjahr und Jahresbudget Felder wurden für Region, Center und Verein ergänzt (#19)
+* Beim Erstellen einer Person kann jetzt die Sprache gesetzt werden (#140)

--- a/app/views/people/_fields_swb.html.haml
+++ b/app/views/people/_fields_swb.html.haml
@@ -4,6 +4,12 @@
 -#  https://github.com/hitobito/hitobito_swb.
 
 = f.labeled_country_select(:nationality)
+= f.labeled_collection_select(:language,
+                              Person::LANGUAGES,
+                              :first,
+                              :last,
+                              { prompt: true },
+                              class: 'form-select form-select-sm')
 = f.labeled_input_field(:international_player_id)
 = f.labeled_input_field(:emergency_contact)
 = f.labeled(t('.label_email_settings')) do

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -181,6 +181,7 @@ describe RolesController do
                 town: "Ivanstadt",
                 country: "CH",
                 nationality: "CH",
+                language: "fr",
                 gender: "m",
                 phone_numbers_attributes: {"0" => {translated_label: "Mobil", number: "0781234567",
                                                    public: false}}
@@ -190,6 +191,24 @@ describe RolesController do
         end.to change { Role.count }.by(1)
           .and change { Person.count }.by(1)
           .and change { PhoneNumber.count }.by(1)
+
+        created_person = Person.last
+        expect(created_person).to have_attributes({
+          first_name: "Dario",
+          last_name: "Ahlke",
+          email: "dario.ahlke2@hitobito.example.com",
+          birthday: Date.parse("03.02.1983"),
+          street: "Bahnhof Str.",
+          housenumber: "2",
+          zip_code: "6414",
+          town: "Ivanstadt",
+          country: "CH",
+          nationality: "CH",
+          language: "fr",
+          gender: "m"
+        })
+
+        expect(created_person.phone_numbers.first.number).to eq "+41 78 123 45 67"
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/hitobito/hitobito_swb/issues/140

Edit: Leider hat sich ein Typo in der Commit-Message eingeschlichen (sww statt swb), darum wird der Commit in der falschen Story erwähnt. 