### PR TITLE
Fix duplicate language field in person and event forms

### DIFF
--- a/app/views/event/participation_contact_datas/_fields_swb.html.haml
+++ b/app/views/event/participation_contact_datas/_fields_swb.html.haml
@@ -3,4 +3,4 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_swb.
 
-= render 'people/fields_swb', f: f
+= render 'people/swb_fields', f: f

--- a/app/views/people/_fields_swb.html.haml
+++ b/app/views/people/_fields_swb.html.haml
@@ -3,15 +3,4 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_swb.
 
-= f.labeled_country_select(:nationality)
-= f.labeled_collection_select(:language,
-                              Person::LANGUAGES,
-                              :first,
-                              :last,
-                              { prompt: true },
-                              class: 'form-select form-select-sm')
-= f.labeled_input_field(:international_player_id)
-= f.labeled_input_field(:emergency_contact)
-= f.labeled(t('.label_email_settings')) do
-  = f.input_field(:advertising, caption: t('.caption_advertising'))
-  = f.input_field(:newsletter, caption: t('.caption_newsletter'))
+= render 'people/swb_fields', f: f

--- a/app/views/people/_swb_fields.html.haml
+++ b/app/views/people/_swb_fields.html.haml
@@ -1,0 +1,14 @@
+-#  Copyright (c) 2012-2025, Swiss Badminton. This file is part of
+-#  hitobito_swb and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_swb.
+
+-# SWB-specific form fields that are shared across multiple forms.
+-# Not to be confused with the _fields_swb partial.
+
+= f.labeled_country_select(:nationality)
+= f.labeled_input_field(:international_player_id)
+= f.labeled_input_field(:emergency_contact)
+= f.labeled(t('.label_email_settings')) do
+  = f.input_field(:advertising, caption: t('.caption_advertising'))
+  = f.input_field(:newsletter, caption: t('.caption_newsletter'))

--- a/app/views/roles/_person_fields_swb.html.haml
+++ b/app/views/roles/_person_fields_swb.html.haml
@@ -3,4 +3,11 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_swb.
 
-= render 'people/fields_swb', f: f
+= f.labeled_collection_select(:language,
+                              Person::LANGUAGES,
+                              :first,
+                              :last,
+                              { prompt: true },
+                              class: 'form-select form-select-sm')
+
+= render 'people/swb_fields', f: f

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -672,7 +672,7 @@ de:
     external_trainings: Ausbildungen
 
   people:
-    fields_swb:
+    swb_fields:
       label_email_settings: Mailversand
       caption_newsletter: Ich möchte den Newsletter erhalten
       caption_advertising: Ich möchte Dienstleistungs-Angebote erhalten

--- a/config/locales/wagon.en.yml
+++ b/config/locales/wagon.en.yml
@@ -669,7 +669,7 @@ en:
     external_trainings: Ausbildungen
 
   people:
-    fields_swb:
+    swb_fields:
       label_email_settings: Mailversand
       caption_newsletter: Ich möchte den Newsletter erhalten
       caption_advertising: Ich möchte Dienstleistungs-Angebote erhalten

--- a/config/locales/wagon.fr.yml
+++ b/config/locales/wagon.fr.yml
@@ -782,7 +782,7 @@ fr:
     external_trainings: Formations
 
   people:
-    fields_swb:
+    swb_fields:
       label_email_settings: Envoi de mail
       caption_newsletter: Je souhaite recevoir la newsletter.
       caption_advertising: Je souhaite recevoir des offres de partenaires.

--- a/config/locales/wagon.it.yml
+++ b/config/locales/wagon.it.yml
@@ -669,7 +669,7 @@ it:
     external_trainings: Ausbildungen
 
   people:
-    fields_swb:
+    swb_fields:
       label_email_settings: Mailversand
       caption_newsletter: Ich möchte den Newsletter erhalten
       caption_advertising: Ich möchte Dienstleistungs-Angebote erhalten


### PR DESCRIPTION
Problem:
Commit 928129adb accidentally introduced a duplicate language field in two forms:
- Event registration
- Person editing

Root Cause:
The `people/_fields_swb` partial was extended to include the language field, but this partial is shared across three different forms:
- Adding new role
- Editing person
- Registering for event

Solution:
Extracted SWB-specific fields into a new `people/swb_fields` partial. This new partial is now included in all three forms, with the language field appearing only in the "add new role" form where it's needed.