### PR TITLE
Add new roles to verein spieler (#179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,138 +13,144 @@ of Swiss Badminton.
 <!-- roles:start -->
     * Dachverband
       * Dachverband
-        * Administrator:in: [:admin, :layer_and_below_full, :impersonation]
+        * Administrator:in: [:admin, :layer_and_below_full, :impersonation]  --  (Group::Dachverband::Administrator)
       * Vorstand
-        * Präsident:in: [:layer_full]
-        * Vizepräsident:in: [:layer_full]
-        * Vorstandsmitglied: [:layer_full]
+        * Präsident:in: [:layer_full]  --  (Group::DachverbandVorstand::Praesident)
+        * Vizepräsident:in: [:layer_full]  --  (Group::DachverbandVorstand::Vizepraesident)
+        * Vorstandsmitglied: [:layer_full]  --  (Group::DachverbandVorstand::Mitglied)
       * Geschäftsstelle
-        * Geschäftsführer:in: [:layer_and_below_full, :admin, :approve_applications]
-        * Mitglied: [:group_read]
-        * J+S Coach: [:group_read]
-        * Verantwortliche:r Antidoping: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Ausbildung: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Breitensport: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Club Management: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Ethik: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Event/Turnier: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Finanzen: [:layer_and_below_full, :impersonation, :finance]
-        * Verantwortliche:r Interclub (TS): [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Kommunikation: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Leistungssport: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Marketing: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Medical: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Nachwuchs: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Personal: [:layer_and_below_full, :impersonation]
-        * Verantwortliche:r Umfeld: [:layer_and_below_full, :impersonation]
+        * Geschäftsführer:in: [:layer_and_below_full, :admin, :approve_applications]  --  (Group::DachverbandGeschaeftsstelle::Geschaeftsfuehrer)
+        * Mitglied: [:group_read]  --  (Group::DachverbandGeschaeftsstelle::Mitglied)
+        * J+S Coach: [:group_read]  --  (Group::DachverbandGeschaeftsstelle::JSCoach)
+        * Verantwortliche:r Antidoping: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Antidoping)
+        * Verantwortliche:r Ausbildung: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Ausbildung)
+        * Verantwortliche:r Breitensport: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Breitensport)
+        * Verantwortliche:r Club Management: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Clubmanagement)
+        * Verantwortliche:r Ethik: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Ethik)
+        * Verantwortliche:r Event/Turnier: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::EventTurnier)
+        * Verantwortliche:r Finanzen: [:layer_and_below_full, :impersonation, :finance]  --  (Group::DachverbandGeschaeftsstelle::Finanzen)
+        * Verantwortliche:r Interclub (TS): [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Interclub)
+        * Verantwortliche:r Kommunikation: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Kommunikation)
+        * Verantwortliche:r Leistungssport: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Leistungssport)
+        * Verantwortliche:r Marketing: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Marketing)
+        * Verantwortliche:r Medical: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Medical)
+        * Verantwortliche:r Nachwuchs: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Nachwuchs)
+        * Verantwortliche:r Personal: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Personal)
+        * Verantwortliche:r Umfeld: [:layer_and_below_full, :impersonation]  --  (Group::DachverbandGeschaeftsstelle::Umfeld)
       * Kommission
-        * Leiter:in: [:group_full]
-        * Mitglied: [:group_read]
+        * Leiter:in: [:group_full]  --  (Group::DachverbandKommission::Leitung)
+        * Mitglied: [:group_read]  --  (Group::DachverbandKommission::Mitglied)
       * Kader
-        * Trainer:in: [:group_read]
-        * Athlet:in: [:group_read]
+        * Trainer:in: [:group_read]  --  (Group::DachverbandKader::Trainer)
+        * Athlet:in: [:group_read]  --  (Group::DachverbandKader::Athlet)
       * Spieler:innen
-        * Aktivmitglied (TS): []
-        * Passivmitglied (TS): []
-        * Junior:in (bis U15) (TS): []
-        * Junior:in (U17-U19) (TS): []
-        * Lizenz: []
+        * Aktivmitglied (TS): []  --  (Group::DachverbandSpieler::Aktivmitglied)
+        * Passivmitglied (TS): []  --  (Group::DachverbandSpieler::Passivmitglied)
+        * Lizenz Nachwuchs bis U15 (TS): []  --  (Group::DachverbandSpieler::JuniorU15)
+        * Lizenz Nachwuchs U17-U19 (TS): []  --  (Group::DachverbandSpieler::JuniorU19)
+        * Aktivmitgliedschaft bis U15 (TS): []  --  (Group::DachverbandSpieler::AktivmitgliedU15)
+        * Aktivmitgliedschaft U17-U19 (TS): []  --  (Group::DachverbandSpieler::AktivmitgliedU19)
+        * Lizenz: []  --  (Group::DachverbandSpieler::Lizenz)
       * Technisch / Offiziell
-        * Linienrichter:in: [:group_read]
-        * Referee: [:group_read]
-        * Schiedsrichter:in: [:group_read]
+        * Linienrichter:in: [:group_read]  --  (Group::DachverbandTechnischoffiziell::Linienrichter)
+        * Referee: [:group_read]  --  (Group::DachverbandTechnischoffiziell::Referee)
+        * Schiedsrichter:in: [:group_read]  --  (Group::DachverbandTechnischoffiziell::Schiedsrichter)
       * Kontakte
-        * Kontakt: []
-        * Ehemaliges ZV-Mitglied: []
-        * Ehemalige:r Mitarbeiter:in: []
-        * Ehrenmitglied: []
-        * Shuttletime-Tutor: []
-        * Gönner:in: []
-        * Medien: []
-        * Partner: []
-        * J+S Expert:in: []
+        * Kontakt: []  --  (Group::DachverbandKontakte::Kontakt)
+        * Ehemaliges ZV-Mitglied: []  --  (Group::DachverbandKontakte::EhemaligesZvmitglied)
+        * Ehemalige:r Mitarbeiter:in: []  --  (Group::DachverbandKontakte::EhemaligerMitarbeiter)
+        * Ehrenmitglied: []  --  (Group::DachverbandKontakte::Ehrenmitglied)
+        * Shuttletime-Tutor: []  --  (Group::DachverbandKontakte::ShuttletimeTutor)
+        * Gönner:in: []  --  (Group::DachverbandKontakte::Goenner)
+        * Medien: []  --  (Group::DachverbandKontakte::Medien)
+        * Partner: []  --  (Group::DachverbandKontakte::Partner)
+        * J+S Expert:in: []  --  (Group::DachverbandKontakte::JSExperte)
     * Region < Dachverband
       * Region
-        * J+S Coach: [:group_read]
-        * Verantwortliche:r Antidoping: [:group_read]
-        * Verantwortliche:r Ausbildung: [:group_read]
-        * Verantwortliche:r Breitensport: [:group_read]
-        * Verantwortliche:r Club Management: [:group_read]
-        * Verantwortliche:r Ethik: [:group_read]
-        * Verantwortliche:r Event/Turnier: [:group_read]
-        * Verantwortliche:r Interclub (TS): [:layer_and_below_full]
-        * Verantwortliche:r Kommunikation: [:group_read]
-        * Verantwortliche:r Leistungssport: [:group_read]
-        * Verantwortliche:r Marketing: [:group_read]
-        * Verantwortliche:r Medical: [:group_read]
-        * Verantwortliche:r Nachwuchs: [:group_read]
-        * Verantwortliche:r Personal: [:group_read]
-        * Verantwortliche:r Umfeld: [:group_read]
+        * J+S Coach: [:group_read]  --  (Group::Region::JSCoach)
+        * Verantwortliche:r Antidoping: [:group_read]  --  (Group::Region::Antidoping)
+        * Verantwortliche:r Ausbildung: [:group_read]  --  (Group::Region::Ausbildung)
+        * Verantwortliche:r Breitensport: [:group_read]  --  (Group::Region::Breitensport)
+        * Verantwortliche:r Club Management: [:group_read]  --  (Group::Region::Clubmanagement)
+        * Verantwortliche:r Ethik: [:group_read]  --  (Group::Region::Ethik)
+        * Verantwortliche:r Event/Turnier: [:group_read]  --  (Group::Region::EventTurnier)
+        * Verantwortliche:r Interclub (TS): [:layer_and_below_full]  --  (Group::Region::Interclub)
+        * Verantwortliche:r Kommunikation: [:group_read]  --  (Group::Region::Kommunikation)
+        * Verantwortliche:r Leistungssport: [:group_read]  --  (Group::Region::Leistungssport)
+        * Verantwortliche:r Marketing: [:group_read]  --  (Group::Region::Marketing)
+        * Verantwortliche:r Medical: [:group_read]  --  (Group::Region::Medical)
+        * Verantwortliche:r Nachwuchs: [:group_read]  --  (Group::Region::Nachwuchs)
+        * Verantwortliche:r Personal: [:group_read]  --  (Group::Region::Personal)
+        * Verantwortliche:r Umfeld: [:group_read]  --  (Group::Region::Umfeld)
       * Vorstand
-        * Präsident:in: [:layer_and_below_full]
-        * Vizepräsident:in: [:layer_and_below_full]
-        * Administrator:in: [:layer_and_below_full, :finance]
-        * Verantwortliche:r Finanzen: [:layer_and_below_full, :finance]
-        * Vorstandsmitglied: [:layer_and_below_full]
+        * Präsident:in: [:layer_and_below_full]  --  (Group::RegionVorstand::Praesident)
+        * Vizepräsident:in: [:layer_and_below_full]  --  (Group::RegionVorstand::Vizepraesident)
+        * Administrator:in: [:layer_and_below_full, :finance]  --  (Group::RegionVorstand::Administrator)
+        * Verantwortliche:r Finanzen: [:layer_and_below_full, :finance]  --  (Group::RegionVorstand::Finanzen)
+        * Vorstandsmitglied: [:layer_and_below_full]  --  (Group::RegionVorstand::Mitglied)
       * Spieler:innen
-        * Aktivmitglied (TS): []
-        * Passivmitglied (TS): []
-        * Junior:in (bis U15) (TS): []
-        * Junior:in (U17-U19) (TS): []
-        * Lizenz: []
+        * Aktivmitglied (TS): []  --  (Group::RegionSpieler::Aktivmitglied)
+        * Passivmitglied (TS): []  --  (Group::RegionSpieler::Passivmitglied)
+        * Lizenz Nachwuchs bis U15 (TS): []  --  (Group::RegionSpieler::JuniorU15)
+        * Lizenz Nachwuchs U17-U19 (TS): []  --  (Group::RegionSpieler::JuniorU19)
+        * Aktivmitgliedschaft bis U15 (TS): []  --  (Group::RegionSpieler::AktivmitgliedU15)
+        * Aktivmitgliedschaft U17-U19 (TS): []  --  (Group::RegionSpieler::AktivmitgliedU19)
+        * Lizenz: []  --  (Group::RegionSpieler::Lizenz)
       * Kontakte
-        * Kontakt: []
-        * Medien: []
-        * Partner: []
-        * Ehrenmitglied: []
-        * Partner: []
+        * Kontakt: []  --  (Group::RegionKontakte::Kontakt)
+        * Medien: []  --  (Group::RegionKontakte::Medien)
+        * Partner: []  --  (Group::RegionKontakte::Partner)
+        * Ehrenmitglied: []  --  (Group::RegionKontakte::Ehrenmitglied)
+        * Partner: []  --  (Group::RegionKontakte::Volunteer)
     * Verein < Region
       * Verein
-        * J+S Coach: [:group_read]
-        * Schiedsrichter:in: [:group_read]
-        * Clubtrainer:in (TS): [:group_read]
-        * Nationalliga: [:group_read]
-        * Verantwortliche:r Antidoping: [:group_read]
-        * Verantwortliche:r Ausbildung: [:group_read]
-        * Verantwortliche:r Ethik: [:group_read]
-        * Verantwortliche:r Breitensport: [:group_read]
-        * Verantwortliche:r Club Management: [:group_read]
-        * Verantwortliche:r Event/Turnier (TS): [:group_read]
-        * Verantwortliche:r Interclub (TS): [:layer_full]
-        * Verantwortliche:r Kommunikation: [:group_read]
-        * Verantwortliche:r Leistungssport: [:group_read]
-        * Verantwortliche:r Marketing: [:group_read]
-        * Verantwortliche:r Medical: [:group_read]
-        * Verantwortliche:r Nachwuchs: [:group_read]
-        * Verantwortliche:r Personal: [:group_read]
-        * Verantwortliche:r Umfeld: [:group_read]
+        * J+S Coach: [:group_read]  --  (Group::Verein::JSCoach)
+        * Schiedsrichter:in: [:group_read]  --  (Group::Verein::Schiedsrichter)
+        * Clubtrainer:in (TS): [:group_read]  --  (Group::Verein::Clubtrainer)
+        * Nationalliga: [:group_read]  --  (Group::Verein::Nationalliga)
+        * Verantwortliche:r Antidoping: [:group_read]  --  (Group::Verein::Antidoping)
+        * Verantwortliche:r Ausbildung: [:group_read]  --  (Group::Verein::Ausbildung)
+        * Verantwortliche:r Ethik: [:group_read]  --  (Group::Verein::Ethik)
+        * Verantwortliche:r Breitensport: [:group_read]  --  (Group::Verein::Breitensport)
+        * Verantwortliche:r Club Management: [:group_read]  --  (Group::Verein::Clubmanagement)
+        * Verantwortliche:r Event/Turnier (TS): [:group_read]  --  (Group::Verein::EventTurnier)
+        * Verantwortliche:r Interclub (TS): [:layer_full]  --  (Group::Verein::Interclub)
+        * Verantwortliche:r Kommunikation: [:group_read]  --  (Group::Verein::Kommunikation)
+        * Verantwortliche:r Leistungssport: [:group_read]  --  (Group::Verein::Leistungssport)
+        * Verantwortliche:r Marketing: [:group_read]  --  (Group::Verein::Marketing)
+        * Verantwortliche:r Medical: [:group_read]  --  (Group::Verein::Medical)
+        * Verantwortliche:r Nachwuchs: [:group_read]  --  (Group::Verein::Nachwuchs)
+        * Verantwortliche:r Personal: [:group_read]  --  (Group::Verein::Personal)
+        * Verantwortliche:r Umfeld: [:group_read]  --  (Group::Verein::Umfeld)
       * Vorstand
-        * Präsident:in: [:layer_full, :players_group_read]
-        * Vizepräsident:in: [:layer_full, :players_group_read]
-        * Verantwortliche:r Finanzen: [:layer_full, :finance]
-        * Vorstandsmitglied: [:layer_full, :players_group_read]
-        * Administrator:in: [:layer_full, :finance]
+        * Präsident:in: [:layer_full, :players_group_read]  --  (Group::VereinVorstand::Praesident)
+        * Vizepräsident:in: [:layer_full, :players_group_read]  --  (Group::VereinVorstand::Vizepraesident)
+        * Verantwortliche:r Finanzen: [:layer_full, :finance]  --  (Group::VereinVorstand::Finanzen)
+        * Vorstandsmitglied: [:layer_full, :players_group_read]  --  (Group::VereinVorstand::Mitglied)
+        * Administrator:in: [:layer_full, :finance]  --  (Group::VereinVorstand::Administrator)
       * Spieler:innen
-        * Aktivmitglied (TS): []
-        * Passivmitglied (TS): []
-        * Junior:in (bis U15) (TS): []
-        * Junior:in (U17-U19) (TS): []
-        * Lizenz (TS): []
-        * Lizenz Plus Junior:innen (U19) (TS): []
-        * Lizenz Plus (TS): []
-        * Lizenz NO ranking (TS): []
-        * Vereinigungsspieler:in (TS): []
+        * Aktivmitglied (TS): []  --  (Group::VereinSpieler::Aktivmitglied)
+        * Passivmitglied (TS): []  --  (Group::VereinSpieler::Passivmitglied)
+        * Lizenz Nachwuchs bis U15 (TS): []  --  (Group::VereinSpieler::JuniorU15)
+        * Lizenz Nachwuchs U17-U19 (TS): []  --  (Group::VereinSpieler::JuniorU19)
+        * Aktivmitgliedschaft bis U15 (TS): []  --  (Group::VereinSpieler::AktivmitgliedU15)
+        * Aktivmitgliedschaft U17-U19 (TS): []  --  (Group::VereinSpieler::AktivmitgliedU19)
+        * Lizenz (TS): []  --  (Group::VereinSpieler::Lizenz)
+        * Lizenz Plus Nachwuchs (U19) (TS): []  --  (Group::VereinSpieler::LizenzPlusJunior)
+        * Lizenz Plus (TS): []  --  (Group::VereinSpieler::LizenzPlus)
+        * Lizenz NO ranking (TS): []  --  (Group::VereinSpieler::LizenzNoRanking)
+        * Vereinigungsspieler:in (TS): []  --  (Group::VereinSpieler::Vereinigungsspieler)
       * Kontakte
-        * Kontakt: []
-        * Medien: []
-        * Partner: []
-        * Ehrenmitglied: []
-        * Partner: []
+        * Kontakt: []  --  (Group::VereinKontakte::Kontakt)
+        * Medien: []  --  (Group::VereinKontakte::Medien)
+        * Partner: []  --  (Group::VereinKontakte::Partner)
+        * Ehrenmitglied: []  --  (Group::VereinKontakte::Ehrenmitglied)
+        * Partner: []  --  (Group::VereinKontakte::Volunteer)
     * Center (Mitglied) < Dachverband
       * Center (Mitglied)
-        * Direktion: [:group_full]
+        * Direktion: [:group_full]  --  (Group::Center::Direktion)
     * Center < Dachverband
       * Center
-        * Direktion: [:group_full]
+        * Direktion: [:group_full]  --  (Group::CenterUnaffilliated::Direktion)
 (Output of rake app:hitobito:roles)
 <!-- roles:end -->

--- a/app/domain/roles/players/checker.rb
+++ b/app/domain/roles/players/checker.rb
@@ -9,6 +9,13 @@ module Roles::Players
   class Checker
     attr_reader :role, :type, :current_type, :upgrades
 
+    JUNIOR_TYPES = [
+      "JuniorU15",
+      "JuniorU19",
+      "AktivmitgliedU15",
+      "AktivmitgliedU19"
+    ]
+
     delegate :group, to: :role
 
     def initialize(role)
@@ -19,7 +26,7 @@ module Roles::Players
     end
 
     def junior?
-      ["JuniorU15", "JuniorU19"].include?(type)
+      JUNIOR_TYPES.include?(type)
     end
 
     def upgrade?

--- a/app/domain/roles/players/phases/restricted.rb
+++ b/app/domain/roles/players/phases/restricted.rb
@@ -6,10 +6,8 @@
 #  https://github.com/hitobito/hitobito_swb.
 
 module Roles::Players::Phases
-  # rubocop:todo Layout/LineLength
-  # During phase_3, nothing besides the creation of certain roles is allowed, no upgrades/downgrades, no deletions
-  # rubocop:enable Layout/LineLength
-  # Only junior roles can be created
+  # During phase_3, nothing besides the creation of certain roles is allowed,
+  # no upgrades/downgrades, no deletions. Only junior roles can be created
   class Restricted < Base
     def create?
       checker.new? && checker.junior?

--- a/app/domain/roles/players/promotion.rb
+++ b/app/domain/roles/players/promotion.rb
@@ -52,7 +52,11 @@ module Roles::Players
 
     def role_type_for(role)
       years = Time.zone.now.year - role.person.birthday.year
-      type = Role::Player::JuniorU19.year_range.include?(years) ? "JuniorU19" : "Lizenz"
+      type = if Role::Player::JuniorU19.year_range.include?(years)
+        role.type.gsub("U15", "U19").demodulize
+      else
+        "Lizenz"
+      end
       [role.type.deconstantize, type].join("::").constantize
     end
 

--- a/app/domain/swb_import.rb
+++ b/app/domain/swb_import.rb
@@ -150,12 +150,22 @@ module SwbImport
     ["Passiv",
       [Group::DachverbandSpieler::Passivmitglied, Group::RegionSpieler::Passivmitglied,
         Group::VereinSpieler::Passivmitglied]],
-    ["Junior (U17-U19)",
-      [Group::DachverbandSpieler::JuniorU19, Group::RegionSpieler::JuniorU19,
-        Group::VereinSpieler::JuniorU19]],
-    ["Junior (up to U15)",
-      [Group::DachverbandSpieler::JuniorU15, Group::RegionSpieler::JuniorU15,
-        Group::VereinSpieler::JuniorU15]],
+    ["Junior (U17-U19)", [
+      Group::DachverbandSpieler::JuniorU19,
+      Group::RegionSpieler::JuniorU19,
+      Group::VereinSpieler::JuniorU19,
+      Group::DachverbandSpieler::AktivmitgliedU19,
+      Group::RegionSpieler::AktivmitgliedU19,
+      Group::VereinSpieler::AktivmitgliedU19
+    ]],
+    ["Junior (up to U15)", [
+      Group::DachverbandSpieler::JuniorU15,
+      Group::RegionSpieler::JuniorU15,
+      Group::VereinSpieler::JuniorU15,
+      Group::DachverbandSpieler::AktivmitgliedU15,
+      Group::RegionSpieler::AktivmitgliedU15,
+      Group::VereinSpieler::AktivmitgliedU15
+    ]],
 
     ["Lizenz", Group::VereinSpieler::Lizenz],
     ["Lizenz NO ranking", Group::VereinSpieler::LizenzNoRanking],

--- a/app/models/group/dachverband_spieler.rb
+++ b/app/models/group/dachverband_spieler.rb
@@ -20,9 +20,21 @@ class Group::DachverbandSpieler < ::Group
   class JuniorU19 < ::Role::Player::JuniorU19
   end
 
+  class AktivmitgliedU15 < JuniorU15
+  end
+
+  class AktivmitgliedU19 < JuniorU19
+  end
+
   class Lizenz < ::Role::Player
     self.unique_across_layers = true
   end
 
-  roles Aktivmitglied, Passivmitglied, JuniorU15, JuniorU19, Lizenz
+  roles Aktivmitglied,
+    Passivmitglied,
+    JuniorU15,
+    JuniorU19,
+    AktivmitgliedU15,
+    AktivmitgliedU19,
+    Lizenz
 end

--- a/app/models/group/region_spieler.rb
+++ b/app/models/group/region_spieler.rb
@@ -22,9 +22,21 @@ class Group::RegionSpieler < ::Group
   class JuniorU19 < ::Role::Player::JuniorU19
   end
 
+  class AktivmitgliedU15 < JuniorU15
+  end
+
+  class AktivmitgliedU19 < JuniorU19
+  end
+
   class Lizenz < ::Role::Player
     self.unique_across_layers = true
   end
 
-  roles Aktivmitglied, Passivmitglied, JuniorU15, JuniorU19, Lizenz
+  roles Aktivmitglied,
+    Passivmitglied,
+    JuniorU15,
+    JuniorU19,
+    AktivmitgliedU15,
+    AktivmitgliedU19,
+    Lizenz
 end

--- a/app/models/group/verein_spieler.rb
+++ b/app/models/group/verein_spieler.rb
@@ -22,6 +22,12 @@ class Group::VereinSpieler < ::Group
   class JuniorU19 < ::Role::Player::JuniorU19
   end
 
+  class AktivmitgliedU15 < JuniorU15
+  end
+
+  class AktivmitgliedU19 < JuniorU19
+  end
+
   class Lizenz < ::Role::Player
     self.unique_across_layers = true
   end
@@ -47,6 +53,8 @@ class Group::VereinSpieler < ::Group
     Passivmitglied,
     JuniorU15,
     JuniorU19,
+    AktivmitgliedU15,
+    AktivmitgliedU19,
     Lizenz,
     LizenzPlusJunior,
     LizenzPlus,

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -215,12 +215,20 @@ de:
         other: Passivmitglieder
 
       group/dachverband_spieler/junior_u15:
-        one: "Junior:in (bis U15)"
-        other: "Junior:innen (bis U15)"
+        one: "Lizenz Nachwuchs bis U15"
+        other: "Lizenzen Nachwuchs bis U15"
 
       group/dachverband_spieler/junior_u19:
-        one: "Junior:in (U17-U19)"
-        other: "Junior:innen (U17-U19)"
+        one: "Lizenz Nachwuchs U17-U19"
+        other: "Lizenzen Nachwuchs U17-U19"
+
+      group/dachverband_spieler/aktivmitglied_u15:
+        one: "Aktivmitgliedschaft bis U15"
+        other: "Aktivmitgliedschaften bis U15"
+
+      group/dachverband_spieler/aktivmitglied_u19:
+        one: "Aktivmitgliedschaft U17-U19"
+        other: "Aktivmitgliedschaften U17-U19"
 
       group/dachverband_spieler/lizenz:
         one: Lizenz
@@ -355,12 +363,20 @@ de:
         other: Passivmitglieder
 
       group/region_spieler/junior_u15:
-        one: "Junior:in (bis U15)"
-        other: "Junior:innen (bis U15)"
+        one: "Lizenz Nachwuchs bis U15"
+        other: "Lizenzen Nachwuchs bis U15"
 
       group/region_spieler/junior_u19:
-        one: "Junior:in (U17-U19)"
-        other: "Junior:innen (U17-U19)"
+        one: "Lizenz Nachwuchs U17-U19"
+        other: "Lizenzen Nachwuchs U17-U19"
+
+      group/region_spieler/aktivmitglied_u15:
+        one: "Aktivmitgliedschaft bis U15"
+        other: "Aktivmitgliedschaften bis U15"
+
+      group/region_spieler/aktivmitglied_u19:
+        one: "Aktivmitgliedschaft U17-U19"
+        other: "Aktivmitgliedschaften U17-U19"
 
       group/region_spieler/lizenz:
         one: Lizenz
@@ -479,12 +495,20 @@ de:
         other: Passivmitglieder
 
       group/verein_spieler/junior_u15:
-        one: "Junior:in (bis U15)"
-        other: "Junior:innen (bis U15)"
+        one: "Lizenz Nachwuchs bis U15"
+        other: "Lizenzen Nachwuchs bis U15"
 
       group/verein_spieler/junior_u19:
-        one: "Junior:in (U17-U19)"
-        other: "Junior:innen (U17-U19)"
+        one: "Lizenz Nachwuchs U17-U19"
+        other: "Lizenzen Nachwuchs U17-U19"
+
+      group/verein_spieler/aktivmitglied_u15:
+        one: "Aktivmitgliedschaft bis U15"
+        other: "Aktivmitgliedschaften bis U15"
+
+      group/verein_spieler/aktivmitglied_u19:
+        one: "Aktivmitgliedschaft U17-U19"
+        other: "Aktivmitgliedschaften U17-U19"
 
       group/verein_spieler/lizenz:
         one: Lizenz
@@ -495,8 +519,8 @@ de:
         other: Vereinigungsspieler:innen
 
       group/verein_spieler/lizenz_plus_junior:
-        one: "Lizenz Plus Junior:innen (U19)"
-        other: "Lizenzen Plus Junior:innen (U19)"
+        one: "Lizenz Plus Nachwuchs (U19)"
+        other: "Lizenzen Plus Nachwuchs (U19)"
 
       group/verein_spieler/lizenz_plus:
         one: Lizenz Plus

--- a/spec/domain/roles/players/checker_spec.rb
+++ b/spec/domain/roles/players/checker_spec.rb
@@ -18,6 +18,8 @@ describe Roles::Players::Checker do
   it "#junior? knows about what roles are junior" do
     expect(check("JuniorU15")).to be_junior
     expect(check("JuniorU19")).to be_junior
+    expect(check("AktivmitgliedU15")).to be_junior
+    expect(check("AktivmitgliedU19")).to be_junior
     expect(check("LizenzPlusJunior")).not_to be_junior
     expect(check("Aktivmitglied")).not_to be_junior
     expect(check("Lizenz")).not_to be_junior

--- a/spec/domain/roles/players/promotion_spec.rb
+++ b/spec/domain/roles/players/promotion_spec.rb
@@ -56,7 +56,7 @@ describe Roles::Players::Promotion do
         # rubocop:enable Layout/LineLength
         expect(log.category).to eq "promotion"
         expect(log.level).to eq "info"
-        expect(log.message).to start_with "Promoted Junior:in (bis U15)"
+        expect(log.message).to start_with "Promoted Lizenz Nachwuchs bis U15"
         expect { role.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -84,7 +84,7 @@ describe Roles::Players::Promotion do
           expect(log.subject).to eq role
           expect(log.category).to eq "promotion"
           expect(log.level).to eq "error"
-          expect(log.message).to start_with "Failed to promote Junior:in (bis U15)"
+          expect(log.message).to start_with "Failed to promote Lizenz Nachwuchs bis U15"
         end
 
         it "continues with promotion if one fails" do
@@ -155,6 +155,27 @@ describe Roles::Players::Promotion do
       expect(thun_spieler.roles.first.type).to eq "Group::VereinSpieler::Lizenz"
       expect(region_spieler.roles.first.type).to eq "Group::RegionSpieler::Lizenz"
       expect(root_spieler.roles.first.type).to eq "Group::DachverbandSpieler::Lizenz"
+    end
+  end
+
+  context "Junioren aktivmitglider" do
+    it "promotes AktivmitgliedU15 to AktivmitgliedU19" do
+      person = create_spieler(Group::VereinSpieler::AktivmitgliedU15, groups(:bc_thun_spieler),
+        birthday: 16.years.ago.end_of_year)
+      expect do
+        described_class.new(Role::Player::JuniorU15).run
+      end.to change { person.reload.roles.map(&:type) }
+        .from(%w[Group::VereinSpieler::AktivmitgliedU15])
+        .to(%w[Group::VereinSpieler::AktivmitgliedU19])
+    end
+    it "promotes AktivmitgliedU19 to Lizenz" do
+      person = create_spieler(Group::VereinSpieler::AktivmitgliedU19, groups(:bc_thun_spieler),
+        birthday: 19.years.ago.end_of_year)
+      expect do
+        described_class.new(Role::Player::JuniorU19).run
+      end.to change { person.reload.roles.map(&:type) }
+        .from(%w[Group::VereinSpieler::AktivmitgliedU19])
+        .to(%w[Group::VereinSpieler::Lizenz])
     end
   end
 end

--- a/spec/features/period_invoice_templates_spec.rb
+++ b/spec/features/period_invoice_templates_spec.rb
@@ -135,22 +135,22 @@ describe PeriodInvoiceTemplatesController, js: true do
         add_item("Rollen-Abrechnung", name_de: "Aktivmitglieder",
           name_fr: "Membres actifs", unit_cost: 30, cost_center: "3003",
           account: "CH56 0483 5035 4099 6000 0") do
-          select_role_type("Aktivmitglied")
+          select_role_type("Aktivmitglied (TS)")
         end
         add_item("Rollen-Abrechnung", name_de: "Passivmitglieder",
           name_fr: "Membres passif", unit_cost: 0, cost_center: "3003",
           account: "CH56 0483 5035 4099 6000 0") do
-          select_role_type("Passivmitglied")
+          select_role_type("Passivmitglied (TS)")
         end
-        add_item("Rollen-Abrechnung", name_de: "Junior:innen (bis U15)",
+        add_item("Rollen-Abrechnung", name_de: "Lizenzen Nachwuchs bis U15",
           name_fr: "Junior.e.s (jusqu'à U15)", unit_cost: 20, cost_center: "3003",
           account: "CH56 0483 5035 4099 6000 0") do
-          select_role_type("Junior:in (bis U15) (TS)")
+          select_role_type("Lizenz Nachwuchs bis U15 (TS)")
         end
-        add_item("Rollen-Abrechnung", name_de: "Junior:innen (U17-U19)",
+        add_item("Rollen-Abrechnung", name_de: "Lizenzen Nachwuchs U17-U19",
           name_fr: "Junior.e.s (U17-U19)", unit_cost: 40, cost_center: "3003",
           account: "CH56 0483 5035 4099 6000 0") do
-          select_role_type("Junior:in (U17-U19) (TS)")
+          select_role_type("Lizenz Nachwuchs U17-U19 (TS)")
         end
         add_item("Rollen-Abrechnung", name_de: "Lizenzen",
           name_fr: "Licences", unit_cost: 120, cost_center: "3003",
@@ -167,10 +167,10 @@ describe PeriodInvoiceTemplatesController, js: true do
           account: "CH56 0483 5035 4099 6000 0") do
           select_role_type("Lizenz NO ranking (TS)")
         end
-        add_item("Rollen-Abrechnung", name_de: "Lizenzen Plus Junior:innen (U19)",
+        add_item("Rollen-Abrechnung", name_de: "Lizenzen Plus Nachwuchs (U19)",
           name_fr: "Licences plus junior.e.s (U19)", unit_cost: 20, cost_center: "3003",
           account: "CH56 0483 5035 4099 6000 0") do
-          select_role_type("Lizenz Plus Junior:innen (U19) (TS)")
+          select_role_type("Lizenz Plus Nachwuchs (U19) (TS)")
         end
         add_item("Rollen-Abrechnung", name_de: "Vereinigungsspieler:innen",
           name_fr: "Joueur.se.s d'une union", unit_cost: 0, cost_center: "3003",
@@ -188,9 +188,9 @@ describe PeriodInvoiceTemplatesController, js: true do
       expect(entry.recipient_source.parent_id).to eq group.id
       expect(entry.items.length).to be 9
       expect(entry.items.map(&:type)).to eq(Array.new(9, "PeriodInvoiceTemplate::RoleCountItem"))
-      expect(entry.items.map(&:name)).to eq(["Aktivmitglieder", "Passivmitglieder", "Junior:innen (bis U15)",
-        "Junior:innen (U17-U19)", "Lizenzen", "Lizenzen Plus", "Lizenzen NO ranking",
-        "Lizenzen Plus Junior:innen (U19)", "Vereinigungsspieler:innen"])
+      expect(entry.items.map(&:name)).to eq(["Aktivmitglieder", "Passivmitglieder", "Lizenzen Nachwuchs bis U15",
+        "Lizenzen Nachwuchs U17-U19", "Lizenzen", "Lizenzen Plus", "Lizenzen NO ranking",
+        "Lizenzen Plus Nachwuchs (U19)", "Vereinigungsspieler:innen"])
       expect(entry.items.map(&:name_fr)).to eq(["Membres actifs", "Membres passif", "Junior.e.s (jusqu'à U15)",
         "Junior.e.s (U17-U19)", "Licences", "Licences Plus", "Lizenzen NO ranking", "Licences plus junior.e.s (U19)",
         "Joueur.se.s d'une union"])
@@ -199,7 +199,7 @@ describe PeriodInvoiceTemplatesController, js: true do
       }).to eq(["30.00", "0.00", "20.00", "40.00", "120.00", "50.00", "120.00", "20.00", "0.00"])
       expect(entry.items.map { |item|
         item.dynamic_cost_parameters[:role_types]
-      }).to eq([
+      }).to match_array([
         ["Group::VereinSpieler::Aktivmitglied"],
         ["Group::VereinSpieler::Passivmitglied"],
         ["Group::VereinSpieler::JuniorU15"],
@@ -255,10 +255,10 @@ describe PeriodInvoiceTemplatesController, js: true do
     fill_in "Konto", with: account
   end
 
-  def select_role_type(type)
+  def select_role_type(type) # rubocop:disable Metrics/AbcSize
     click_button "Rollentypen auswählen"
     expect(page).to have_content "Schliessen"
-    all("label", text: type).last.check
+    all("label", text: type).index_by { |x| x.native.text }.fetch(type).check
     click_button "Schliessen"
     expect(page).to have_no_content "Schliessen"
     expect(page).to have_content type

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -204,4 +204,37 @@ describe Role do
       end
     end
   end
+
+  it "has expected ts_managed types" do
+    expect(Role.ts_managed_types).to match_array [
+      "Group::DachverbandGeschaeftsstelle::Interclub",
+      "Group::DachverbandSpieler::Aktivmitglied",
+      "Group::DachverbandSpieler::AktivmitgliedU15",
+      "Group::DachverbandSpieler::AktivmitgliedU19",
+      "Group::DachverbandSpieler::JuniorU15",
+      "Group::DachverbandSpieler::JuniorU19",
+      "Group::DachverbandSpieler::Passivmitglied",
+      "Group::Region::Interclub",
+      "Group::RegionSpieler::Aktivmitglied",
+      "Group::RegionSpieler::AktivmitgliedU15",
+      "Group::RegionSpieler::AktivmitgliedU19",
+      "Group::RegionSpieler::JuniorU15",
+      "Group::RegionSpieler::JuniorU19",
+      "Group::RegionSpieler::Passivmitglied",
+      "Group::Verein::Clubtrainer",
+      "Group::Verein::EventTurnier",
+      "Group::Verein::Interclub",
+      "Group::VereinSpieler::Aktivmitglied",
+      "Group::VereinSpieler::AktivmitgliedU15",
+      "Group::VereinSpieler::AktivmitgliedU19",
+      "Group::VereinSpieler::JuniorU15",
+      "Group::VereinSpieler::JuniorU19",
+      "Group::VereinSpieler::Lizenz",
+      "Group::VereinSpieler::LizenzNoRanking",
+      "Group::VereinSpieler::LizenzPlus",
+      "Group::VereinSpieler::LizenzPlusJunior",
+      "Group::VereinSpieler::Passivmitglied",
+      "Group::VereinSpieler::Vereinigungsspieler"
+    ]
+  end
 end


### PR DESCRIPTION
Ersters Wurf, bisher wurden nur die Anpassung nur auf Ebene Verein gemacht. Die neuen Rollen wurden ergänzt und die notwendigen Anpassungen gemacht (promotion, phase check).

Folgendes ist noch offen

- [ ] Anpassungen der Übersetzugen in Transifex
- [x] Anpassung auch auf Ebene Region und Dachverband? -> ja 
- [x] Neue Rollen bei Sammelrechnungen ergänzen -> @ThomasEllenberger erklärt das dem SWB
- [x] Datenmigration -> Falls ja, folgeticket erstellen


