### PR TITLE
Cleanup collection select calls 🤖

### DIFF
--- a/app/views/player_transfers/new.html.haml
+++ b/app/views/player_transfers/new.html.haml
@@ -6,5 +6,5 @@
 = standard_form(player_transfer, url: group_role_player_transfer_path(*parents)) do |f|
   = f.error_messages
   = f.labeled(:target_id) do
-    = f.collection_select(:target_id, targets, :first, :last, {prompt: true}, class: "form-select form-select-sm")
+    = f.collection_select(:target_id, targets, :first, :last, {prompt: true})
   = form_buttons(f, submit_label: t(".submit_label"), cancel_url: group_person_path(role.group, role.person))

--- a/app/views/roles/_person_fields_swb.html.haml
+++ b/app/views/roles/_person_fields_swb.html.haml
@@ -7,7 +7,6 @@
                               Person::LANGUAGES,
                               :first,
                               :last,
-                              { prompt: true },
-                              class: 'form-select form-select-sm')
+                              { prompt: true })
 
 = render 'people/swb_fields', f: f


### PR DESCRIPTION
Remove now-redundant class: 'form-select form-select-sm' defaults from
collection_select/labeled_collection_select calls, now that
StandardFormBuilder#collection_select applies this class by default.
